### PR TITLE
Use latest node-sass to enable Node 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "compression": "1.5.2",
     "express": "4.13.3",
     "forever": "0.15.1",
-    "node-sass": "3.2.0",
+    "node-sass": "3.3.3",
     "react": "0.14.0",
     "react-dom": "0.14.0",
     "uglify-js": "2.4.19"


### PR DESCRIPTION
After this change, we can use 4.x series of Node. Tested with 4.1.2
